### PR TITLE
fixed comment inside .env.example file in the cross cutting concerns

### DIFF
--- a/packages/deployment/docker-compose-cross-cutting/.env.sample
+++ b/packages/deployment/docker-compose-cross-cutting/.env.sample
@@ -39,6 +39,6 @@ AUTH_N_TOKEN_LIFE_SECS=604800
 AUTH_N_DEFAULT_AUDIENCE=mojaloop.vnext.dev.default_audience
 AUTH_N_ISSUER_NAME=mojaloop.vnext.dev.default_issuer
 
-// for apps
+#for apps
 AUTH_N_TOKEN_AUDIENCE=${AUTH_N_DEFAULT_AUDIENCE}
 AUTH_N_TOKEN_ISSUER_NAME=${AUTH_N_ISSUER_NAME}


### PR DESCRIPTION
# Chore
* Fixed comment line in .env.example file in `platform-shared-tools/packages/deployment/docker-compose-cross-cutting` from `//` to `#`. It was causing the running of `docker-compose -f ../docker-compose-cross-cutting.yml --env-file ./.env up -d` to fail