### PR TITLE
fix: update UI according to changes from cert-management-bc updates

### DIFF
--- a/packages/admin-ui/src/app/_services_and_types/certificate.service.ts
+++ b/packages/admin-ui/src/app/_services_and_types/certificate.service.ts
@@ -63,7 +63,7 @@ export class CertificatesService {
 	}
 
     getAllPendingCertificates(): Observable<CertificateRequest[]> {
-		let url = `${SVC_BASEURL}/certs/requests/pending`;
+		const url = `${SVC_BASEURL}/certs/requests/pending`;
         return new Observable<any[]>((subscriber) => {
             this.http.get<any[]>(url)
                 .subscribe({

--- a/packages/admin-ui/src/app/_services_and_types/certificate.service.ts
+++ b/packages/admin-ui/src/app/_services_and_types/certificate.service.ts
@@ -47,12 +47,23 @@ export class CertificatesService {
 		});
 	}
 
-    getPendingCertificates(participantId: string | null = null): Observable<CertificateRequest[]> {
+	getCertificatesRequests(participantId: string | null = null): Observable<CertificateRequest[]> {
 		let url = `${SVC_BASEURL}/certs/requests`;
 		if (participantId !== null && participantId !== undefined && participantId !== "") {
 			url += `?participantId=${participantId}`;
 		}
 
+		return new Observable<any[]>((subscriber) => {
+			this.http.get<any[]>(url)
+				.subscribe({
+					next: (certificates) => subscriber.next(certificates),
+					error: (error) => this.handleError(error, subscriber)
+				});
+		});
+	}
+
+    getAllPendingCertificates(): Observable<CertificateRequest[]> {
+		let url = `${SVC_BASEURL}/certs/requests/pending`;
         return new Observable<any[]>((subscriber) => {
             this.http.get<any[]>(url)
                 .subscribe({

--- a/packages/admin-ui/src/app/_services_and_types/certificate_types.ts
+++ b/packages/admin-ui/src/app/_services_and_types/certificate_types.ts
@@ -31,6 +31,12 @@
 
 export type ICertType = "PUBLIC" | "PRIVATE";
 
+export enum CertificateRequestState {
+  "CREATED" = "CREATED",
+  "APPROVED" = "APPROVED",
+  "REJECTED" = "REJECTED"
+}
+
 export interface ICertificateInfo {
     subject: string;
     issuer: string;
@@ -51,11 +57,20 @@ export declare type Certificate = {
     description: string | null;
 	certInfo: ICertificateInfo | null;
 	publicKey: string;
+
+	requestState: CertificateRequestState;
+
     createdBy: string;
     createdDate: number;
+
     approved: boolean;
     approvedBy: string | null;
     approvedDate: number | null;
+
+	rejected: boolean;
+	rejectedBy: string | null;
+	rejectedDate: number | null;
+
     lastUpdated: number;
 }
 

--- a/packages/admin-ui/src/app/participants/participant-detail.component.html
+++ b/packages/admin-ui/src/app/participants/participant-detail.component.html
@@ -849,6 +849,7 @@
 							<th scope="col">Valid From</th>
 							<th scope="col">Valid To</th>
 							<th scope="col">Uploaded By</th>
+							<th scope="col">Status</th>
 						</tr>
 					</thead>
 					<tbody>
@@ -859,11 +860,23 @@
 							<td>{{ approvedCertificate?.certInfo?.validFrom | date : "medium" }}</td>
 							<td>{{ approvedCertificate?.certInfo?.validTo | date : "medium" }}</td>
 							<td>{{ approvedCertificate?.createdBy }}</td>
+							<td>
+								<span *ngIf="approvedCertificate?.requestState == 'CREATED'" class="text-danger">
+									(Pending)
+								</span>
+								<span *ngIf="approvedCertificate?.requestState == 'APPROVED'">
+									Approved by {{ approvedCertificate?.approvedBy }} on
+									{{ approvedCertificate?.approvedDate | date : "medium" }}
+								</span>
+								<span *ngIf="approvedCertificate?.requestState == 'REJECTED'">
+									Rejected by {{ approvedCertificate?.rejectedBy }} on
+									{{ approvedCertificate?.rejectedDate | date : "medium" }}
+								</span>
+							</td>
 						</tr>
 					</tbody>
 				</table>
 			<hr/>
-			<h4 class="mt-3">Participant Certificates</h4>
 			 <!-- Add Certificate Section -->
 			<div class="mt-4">
 			  <p *ngIf="(participant | async)?.approved === false" class="text-danger">
@@ -878,7 +891,7 @@
 
 			<!-- Certificates Pending Approval -->
 			<div class="mt-5">
-				<h5>Pending Certificates for Approval</h5>
+				<h5>Certificates Approval Requests</h5>
 				<table class="table table-hover mt-3">
 					<thead class="thead-light">
 						<tr>
@@ -888,6 +901,7 @@
 							<th scope="col">Valid From</th>
 							<th scope="col">Valid To</th>
 							<th scope="col">Uploaded By</th>
+							<th scope="col">Status</th>
 							<th scope="col">Actions</th>
 						</tr>
 					</thead>
@@ -900,10 +914,27 @@
 							<td>{{ certificate.certInfo?.validTo | date : "medium" }}</td>
 							<td>{{ certificate.createdBy }}</td>
 							<td>
-								<button class="btn btn-success btn-sm" (click)="approveCertificate(certificate._id)">
+								<span *ngIf="certificate.requestState == 'CREATED'" class="text-danger">
+									(Pending)
+								</span>
+								<span *ngIf="certificate.requestState == 'APPROVED'">
+									Approved by {{ certificate.approvedBy }} on
+									{{ certificate.approvedDate | date : "medium" }}
+								</span>
+								<span *ngIf="certificate.requestState == 'REJECTED'">
+									Rejected by {{ certificate.rejectedBy }} on
+									{{ certificate.rejectedDate | date : "medium" }}
+								</span>
+							</td>
+							<td>
+								<button class="btn btn-success btn-sm mb-2" *ngIf="certificate.requestState == 'CREATED'"
+									(click)="approveCertificate(certificate._id)" ngbTooltip="Approve">
+									<span class="bi bi-check-lg"></span>
 									Approve
 								</button>
-								<button class="btn btn-danger btn-sm" (click)="rejectCertificate(certificate._id)">
+								<button class="btn btn-danger btn-sm" *ngIf="certificate.requestState == 'CREATED'"
+									(click)="rejectCertificate(certificate._id)" ngbTooltip="Reject">
+									<span class="bi bi-x-lg"></span>
 									Reject
 								</button>
 							</td>

--- a/packages/admin-ui/src/app/participants/participant-detail.component.html
+++ b/packages/admin-ui/src/app/participants/participant-detail.component.html
@@ -927,14 +927,16 @@
 								</span>
 							</td>
 							<td>
-								<button class="btn btn-success btn-sm mb-2" *ngIf="certificate.requestState == 'CREATED'"
-									(click)="approveCertificate(certificate._id)" ngbTooltip="Approve">
-									<span class="bi bi-check-lg"></span>
-								</button>
-								<button class="btn btn-danger btn-sm" *ngIf="certificate.requestState == 'CREATED'"
-									(click)="rejectCertificate(certificate._id)" ngbTooltip="Reject">
-									<span class="bi bi-x-lg"></span>
-								</button>
+								<div class="btn-group btn-group-sm" role="group" aria-label="">
+									<button class="btn-success btn-sm" *ngIf="certificate.requestState == 'CREATED'"
+										(click)="approveCertificate(certificate._id)" ngbTooltip="Approve">
+										<span class="bi bi-check-lg"></span>
+									</button>
+									<button class="btn-danger btn-sm" *ngIf="certificate.requestState == 'CREATED'"
+										(click)="rejectCertificate(certificate._id)" ngbTooltip="Reject">
+										<span class="bi bi-x-lg"></span>
+									</button>
+								</div>
 							</td>
 						</tr>
 					</tbody>

--- a/packages/admin-ui/src/app/participants/participant-detail.component.html
+++ b/packages/admin-ui/src/app/participants/participant-detail.component.html
@@ -930,12 +930,10 @@
 								<button class="btn btn-success btn-sm mb-2" *ngIf="certificate.requestState == 'CREATED'"
 									(click)="approveCertificate(certificate._id)" ngbTooltip="Approve">
 									<span class="bi bi-check-lg"></span>
-									Approve
 								</button>
 								<button class="btn btn-danger btn-sm" *ngIf="certificate.requestState == 'CREATED'"
 									(click)="rejectCertificate(certificate._id)" ngbTooltip="Reject">
 									<span class="bi bi-x-lg"></span>
-									Reject
 								</button>
 							</td>
 						</tr>

--- a/packages/admin-ui/src/app/participants/participant-detail.component.ts
+++ b/packages/admin-ui/src/app/participants/participant-detail.component.ts
@@ -127,7 +127,7 @@ export class ParticipantDetailComponent implements OnInit {
 
 		await this._fetchParticipant();
 		await this.getApprovedCertificate();
-		await this.getPendingCertificates();
+		await this.getCertificatesRequests();
 		this.updateAccounts();
 	}
 
@@ -1284,9 +1284,9 @@ export class ParticipantDetailComponent implements OnInit {
 			});
 	}
 
-	getPendingCertificates(): void {
+	getCertificatesRequests(): void {
 		this._certificatesService
-			.getPendingCertificates(this._participantId)
+			.getCertificatesRequests(this._participantId)
 			.subscribe({
 				next: (CertificateRequests) => {
 					this.pendingCertificates = CertificateRequests.reduce(
@@ -1380,7 +1380,7 @@ export class ParticipantDetailComponent implements OnInit {
 						"modal-btn-cancel",
 					) as HTMLButtonElement;
 
-					this.getPendingCertificates();
+					this.getCertificatesRequests();
 					cancelButton.click();
 					this._messageService.addSuccess(
 						"Certificate uploaded successfully.",
@@ -1396,7 +1396,7 @@ export class ParticipantDetailComponent implements OnInit {
 		this._certificatesService.approveCertificate(certificateId).subscribe({
 			next: () => {
 				// Refresh
-				this.getPendingCertificates();
+				this.getCertificatesRequests();
 				this.getApprovedCertificate();
 				this._messageService.addSuccess(
 					"Certificate approved successfully.",
@@ -1413,7 +1413,7 @@ export class ParticipantDetailComponent implements OnInit {
 			.rejectCertificate(certificateId, this._participantId)
 			.subscribe({
 				next: () => {
-					this.getPendingCertificates();
+					this.getCertificatesRequests();
 					this._messageService.addSuccess(
 						"Certificate rejected successfully.",
 					);

--- a/packages/admin-ui/src/app/participants/pending-approvals.component.ts
+++ b/packages/admin-ui/src/app/participants/pending-approvals.component.ts
@@ -405,7 +405,7 @@ export class PendingApprovalsComponent implements OnInit {
 	}
 
 	getPendingCertificates(): void {
-		this._certificatesService.getPendingCertificates().subscribe({
+		this._certificatesService.getAllPendingCertificates().subscribe({
 			next: (CertificateRequests) => {
 				this.pendingCertificates = CertificateRequests.reduce(
 					(acc: Certificate[], item: CertificateRequest) => {

--- a/packages/deployment/docker-compose-cross-cutting/docker-compose-cross-cutting.yml
+++ b/packages/deployment/docker-compose-cross-cutting/docker-compose-cross-cutting.yml
@@ -27,7 +27,7 @@ services:
     restart: unless-stopped
 
   authentication-svc:
-    image: mojaloop/security-bc-authentication-svc:0.5.2
+    image: mojaloop/security-bc-authentication-svc:0.5.4
 #    volumes:
 #      - authentication-svc_data:/app/data
     environment:
@@ -52,7 +52,7 @@ services:
     restart: unless-stopped
 
   authorization-svc:
-    image: mojaloop/security-bc-authorization-svc:0.5.2
+    image: mojaloop/security-bc-authorization-svc:0.5.4
     environment:
       - KAFKA_URL=${KAFKA_URL}
       - KAFKA_LOGS_TOPIC=${KAFKA_LOGS_TOPIC}
@@ -77,7 +77,7 @@ services:
     restart: unless-stopped
 
   identity-svc:
-    image: mojaloop/security-bc-builtin-identity-svc:0.5.5
+    image: mojaloop/security-bc-builtin-identity-svc:0.5.7
     environment:
       - KAFKA_URL=${KAFKA_URL}
       - KAFKA_LOGS_TOPIC=${KAFKA_LOGS_TOPIC}
@@ -183,7 +183,7 @@ services:
     restart: unless-stopped
 
   mcm-internal-svc:
-    image: mojaloop/cert-management-bc-mcm-internal-svc:0.0.5
+    image: mojaloop/cert-management-bc-mcm-internal-svc:0.0.9
     ports:
       - 3200:3200
     environment:
@@ -198,7 +198,7 @@ services:
       - AUTH_N_TOKEN_AUDIENCE=${AUTH_N_TOKEN_AUDIENCE}
 
   mcm-external-svc:
-    image: mojaloop/cert-management-bc-mcm-external-svc:0.0.5
+    image: mojaloop/cert-management-bc-mcm-external-svc:0.0.6
     ports:
       - 3220:3220
     environment:


### PR DESCRIPTION
update UI and docker image version according to cert-management-bc and security-bc priviledges changes
 
 https://github.com/mojaloop/cert-management-bc/pull/12
https://github.com/mojaloop/cert-management-bc/pull/11
https://github.com/mojaloop/security-bc/pull/10

Might need to reset the MongoDB `security` collection to seed cert-management-bc priviiledges and client id/secrects