### PR TITLE
feat: error events now show human readable information regarding aborted transfers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2792,6 +2792,14 @@
         "tslib": "~2.6.2"
       }
     },
+    "node_modules/@mojaloop/transfers-bc-public-types-lib": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@mojaloop/transfers-bc-public-types-lib/-/transfers-bc-public-types-lib-0.5.2.tgz",
+      "integrity": "sha512-/BPuQTaJROmWkcmRO/1KubFm/s1HXLEO+wHhWi5YHCgGpyvLZx04TBECb7qiFNHz9KZtUvRaDUW1BpGRryPDPA==",
+      "engines": {
+        "node": ">=20.10.0"
+      }
+    },
     "node_modules/@mojaloop/vnext-admin-ui-svc": {
       "resolved": "packages/admin-ui",
       "link": true
@@ -21458,7 +21466,7 @@
     },
     "packages/admin-ui": {
       "name": "@mojaloop/vnext-admin-ui-svc",
-      "version": "0.5.16",
+      "version": "0.5.18",
       "dependencies": {
         "@angular/animations": "~12.2.16",
         "@angular/common": "~12.2.16",
@@ -21474,6 +21482,7 @@
         "@mojaloop/platform-configuration-bc-public-types-lib": "~0.3.5",
         "@mojaloop/security-bc-public-types-lib": "~0.3.5",
         "@mojaloop/settlements-bc-public-types-lib": "~0.3.2",
+        "@mojaloop/transfers-bc-public-types-lib": "~0.5.2",
         "@ng-bootstrap/ng-bootstrap": "^10.0.0",
         "bootstrap": "^4.5.3",
         "buffer": "^6.0.3",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -32,6 +32,7 @@
     "@mojaloop/platform-configuration-bc-public-types-lib": "~0.3.5",
     "@mojaloop/security-bc-public-types-lib": "~0.3.5",
     "@mojaloop/settlements-bc-public-types-lib": "~0.3.2",
+    "@mojaloop/transfers-bc-public-types-lib": "~0.5.2",
     "@ng-bootstrap/ng-bootstrap": "^10.0.0",
     "bootstrap": "^4.5.3",
     "buffer": "^6.0.3",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -32,7 +32,7 @@
     "@mojaloop/platform-configuration-bc-public-types-lib": "~0.3.5",
     "@mojaloop/security-bc-public-types-lib": "~0.3.5",
     "@mojaloop/settlements-bc-public-types-lib": "~0.3.2",
-    "@mojaloop/transfers-bc-public-types-lib": "~0.5.2",
+    "@mojaloop/transfers-bc-public-types-lib": "~0.5.3",
     "@ng-bootstrap/ng-bootstrap": "^10.0.0",
     "bootstrap": "^4.5.3",
     "buffer": "^6.0.3",

--- a/packages/admin-ui/src/app/_services_and_types/transfer_types.ts
+++ b/packages/admin-ui/src/app/_services_and_types/transfer_types.ts
@@ -57,11 +57,7 @@ export declare type Transfer = {
 	payerFspId?: string;
 	currencyCode?: string;
 	completedTimestamp?: string;
-	errorInformation?: IErrorInformation | null;
-}
-
-export interface IErrorInformation {
-	errorCode: string;
+	errorCode?: string | null;
 }
 
 export declare type TransfersSearchResults = {

--- a/packages/admin-ui/src/app/transfers/transfers.component.html
+++ b/packages/admin-ui/src/app/transfers/transfers.component.html
@@ -138,7 +138,7 @@
 			<th scope="col" class="text-center">Payee DFSP Name</th>
 			<th scope="col">Date Submitted</th>
 			<th scope="col">Bulk Transfer ID</th>
-			<th scope="col">Error Code</th>
+			<th scope="col">Error Reason</th>
 		</tr>
 		</thead>
 		<tbody>
@@ -158,8 +158,8 @@
 			<td><a routerLink="/participants/{{item.payerFspId}}">{{item.payerFspId}}</a></td>
 			<td><a routerLink="/participants/{{item.payeeFspId}}">{{item.payeeFspId}}</a></td>
 			<td>{{item.updatedAt | date: 'medium' }}</td>
-			<td><a routerLink="/bulk-transfers/{{item.bulkTransferId}}">{{item.bulkTransferId}}</a></td>
-			<td>{{item?.errorInformation?.errorCode || '-'}}</td>
+			<td><a routerLink="/bulk-transfers/{{item.bulkTransferId}}">{{item.bulkTransferId || '-'}}</a></td>
+			<td>{{item?.errorCode || '-'}}</td>
 		</tr>
 		</tbody>
 	</table>

--- a/packages/admin-ui/src/app/transfers/transfers.component.ts
+++ b/packages/admin-ui/src/app/transfers/transfers.component.ts
@@ -7,6 +7,7 @@ import {MessageService} from "src/app/_services_and_types/message.service";
 import {UnauthorizedError} from "src/app/_services_and_types/errors";
 import {FormBuilder, FormGroup} from '@angular/forms';
 import {HUB_PARTICIPANT_ID, IParticipant} from "@mojaloop/participant-bc-public-types-lib";
+import {TransferErrorCodes} from "@mojaloop/transfers-bc-public-types-lib";
 import {paginate, PaginateResult} from "../_utils";
 
 @Component({
@@ -148,6 +149,8 @@ export class TransfersComponent implements OnInit, OnDestroy {
 			pageSize,
 		).subscribe((result) => {
 			console.log("TransfersComponent search - got TransfersSearchResults");
+
+			result.items.map((transfer) => transfer.errorCode = TransferErrorCodes[transfer.errorCode as keyof typeof TransferErrorCodes])
 
 			this.transfers.next(result.items);
 


### PR DESCRIPTION
Rejected transfers list now presents an human readable error reason matching its domain error definition:

[#Issue 3766](https://app.zenhub.com/workspaces/mojaloop-project-59edee71d1407922110cf083/issues/gh/mojaloop/project/3766)