### PR TITLE
fix: liquidity balance adj type direction not showing in modal popup table.

### DIFF
--- a/packages/admin-ui/src/app/_services_and_types/participant_types.ts
+++ b/packages/admin-ui/src/app/_services_and_types/participant_types.ts
@@ -84,7 +84,7 @@
    bankBalance: number
    settledTransferAmount: string
    currencyCode: string
-   direction: string
+   type: string
    updateAmount: string
    settlementAccountId: string
    isDuplicate: boolean

--- a/packages/admin-ui/src/app/participants/participants.component.html
+++ b/packages/admin-ui/src/app/participants/participants.component.html
@@ -124,7 +124,7 @@
                     (Duplicated <i class="bi bi-exclamation-triangle-fill"></i>)
                   </span>
                 </td>
-                <td>{{ fundAdjustment.direction }}</td>
+                <td>{{ fundAdjustment.type }}</td>
                 <td>{{ fundAdjustment.updateAmount }}</td>
                 <td>{{ fundAdjustment.currencyCode }}</td>
               </tr>


### PR DESCRIPTION
fix: [#4006 Zen Hub issue ticket](https://app.zenhub.com/workspaces/mojaloop-project-59edee71d1407922110cf083/issues/gh/mojaloop/project/4006) or [#4006 Github Issue](https://github.com/mojaloop/project/issues/4006)